### PR TITLE
Removed deprecated script imports for 1.25.0

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -5,6 +5,3 @@ category = "Race"
 
 siteid = 118
 version = "1.10.1"
-
-[script]
-imports = [ "Icons.as", "Formatting.as", "Time.as" ]


### PR DESCRIPTION
You should merge and release this only when 1.25.0 comes out. Not critical by any means, but it'll get rid of some compiler warnings. 😸