### PR TITLE
Added Champion Medals Dependency

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -5,3 +5,7 @@ category = "Race"
 
 siteid = 118
 version = "1.12.0"
+
+
+[script]
+optional_dependencies = [ "ChampionMedals" ]

--- a/info.toml
+++ b/info.toml
@@ -6,6 +6,5 @@ category = "Race"
 siteid = 118
 version = "1.12.0"
 
-
 [script]
 optional_dependencies = [ "ChampionMedals" ]


### PR DESCRIPTION
This adds an optional dependency to the Champion Medals plugin, and displays it like the other medals. 
Some notes:
 - We have to refresh the champion medal a couple of times, because the export function ChampionMedals::GetCMTime returns 0 both if the request failed (in which case we need to try again), and if the map has no champion medal.
 - The Champion Medal is completely hidden from the display if there is none.