### PR TITLE
added column with percentage of players for each medal

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -4,4 +4,4 @@ author = "Phlarx"
 category = "Race"
 
 siteid = 118
-version = "1.12.0"
+version = "1.13.0"


### PR DESCRIPTION
I added a column to the right that shows the player % that got the medals. it also works for pb (and in this case the calculation is only made when the pb changes)

The column is shown by default but can be hidden in settings; Also the options is hidden and disabled in games other than tm2020.

On map with more than 100k players like white campaign maps. It shows an average percentage since we can't get the precise ranking of all players.

![image](https://github.com/Phlarx/tm-ultimate-medals/assets/58704365/7a9e32ae-22c7-4d68-8e5e-f01e23987eb2)

I'm not a developer and it is my first time using github so tells me if i did the request wrong :)
