### PR TITLE
Account for UI scale when rendering

### DIFF
--- a/UltimateMedals.as
+++ b/UltimateMedals.as
@@ -151,7 +151,7 @@ class Record {
 	void DrawIcon() {
 #if TURBO
 		if(5 <= this.medal && this.medal <= 7) {
-			UI::PushStyleVar(UI::StyleVar::ItemSpacing, vec2(0, -fontSize));
+			UI::PushStyleVar(UI::StyleVar::ItemSpacing, vec2(0, -fontSize * UI::GetScale()));
 			UI::Text(medals[this.medal]);
 			UI::Text("\\$0f1" + Icons::CircleO);
 			UI::PopStyleVar();
@@ -446,7 +446,7 @@ void Render() {
 
 void setMinWidth(int width) {
 	UI::PushStyleVar(UI::StyleVar::ItemSpacing, vec2(0, 0));
-	UI::Dummy(vec2(width, 0));
+	UI::Dummy(vec2(width * UI::GetScale(), 0));
 	UI::PopStyleVar();
 }
 


### PR DESCRIPTION
When rendering Super medals in Turbo / setting min column widths, we need to account for the UI scale set by the user

Fixes #45 
| Before  | After  |
|---|---|
| ![image](https://github.com/user-attachments/assets/367378df-083e-4aeb-ba2b-ec7f55af49b6) | ![image](https://github.com/user-attachments/assets/f45259ce-0358-49b7-8077-c4863f7a22f5) |

Fixes columns being too wide when scale < 1

| Before  | After  |
|---|---|
| ![image](https://github.com/user-attachments/assets/5c75731b-ded7-4690-97cb-a973aed63a96) | ![image](https://github.com/user-attachments/assets/2128d514-de05-4f60-9a05-ba6867ea7600) |