### PR TITLE
Simplify table rendering

### DIFF
--- a/Medal.as
+++ b/Medal.as
@@ -31,10 +31,8 @@ abstract class Medal
 		@m_better = better;
 		@m_worse = worse;
 
-		if(showMedalIcons) {
-			UI::TableNextColumn();
-			DrawIcon();
-		}
+		UI::TableNextColumn();
+		DrawIcon();
 
 		UI::TableNextColumn();
 		DrawName();
@@ -42,11 +40,9 @@ abstract class Medal
 		UI::TableNextColumn();
 		DrawScore();
 
-		if (showPbestDelta) {
-			UI::TableNextColumn();
-			if (g_personalBest !is this) {
-				DrawDelta(g_personalBest);
-			}
+		UI::TableNextColumn();
+		if (g_personalBest !is this) {
+			DrawDelta(g_personalBest);
 		}
 
 		@m_better = @m_worse = null;

--- a/UltimateMedals.as
+++ b/UltimateMedals.as
@@ -181,33 +181,26 @@ void Render() {
 			RenderMapComment(mapComment);
 		}
 
-		int numCols = 2; // name and time columns are always shown
-		if(showMedalIcons) numCols++;
-		if(showPbestDelta) numCols++;
-
-		if(UI::BeginTable("table", numCols, UI::TableFlags::SizingFixedFit | UI::TableFlags::NoSavedSettings)) {
-			if (showMedalIcons) {
-				UI::TableSetupColumn("##Icon");
-			}
+		if (UI::BeginTable("table", 4, UI::TableFlags::SizingFixedFit | UI::TableFlags::NoSavedSettings | UI::TableFlags::Hideable)) {
+			UI::TableSetupColumn("##Icon");
 			UI::TableSetupColumn("Medal");
 
 			int scoreUnitTextWidth = int(Draw::MeasureString(tostring(g_scoreUnit)).x);
 			int deltaTextWidth = int(Draw::MeasureString("Delta").x);
 
 			UI::TableSetupColumn("Score", UI::TableColumnFlags::WidthFixed, Math::Max(scoreUnitTextWidth, tableColumnWidth));
-			if (showPbestDelta) {
-				UI::TableSetupColumn("Delta", UI::TableColumnFlags::WidthFixed, Math::Max(deltaTextWidth, tableColumnWidth));
-			}
+			UI::TableSetupColumn("Delta", UI::TableColumnFlags::WidthFixed, Math::Max(deltaTextWidth, tableColumnWidth));
+
+			UI::TableSetColumnEnabled(0, showMedalIcons);
+			UI::TableSetColumnEnabled(3, showPbestDelta);
 
 			if (showHeader) {
 				UI::TableNextRow();
 
 				UI::PushStyleColor(UI::Col::Text, tableHeaderTextColor);
 
-				if (showMedalIcons) {
-					UI::TableNextColumn();
-					// Medal icon has no header text
-				}
+				UI::TableNextColumn();
+				// Medal icon has no header text
 
 				UI::TableNextColumn();
 				UI::Text("Medal");
@@ -216,11 +209,9 @@ void Render() {
 				UI::SetCursorPosX(UI::GetCursorPos().x + UI::GetContentRegionAvail().x - scoreUnitTextWidth);
 				UI::Text(tostring(g_scoreUnit));
 
-				if (showPbestDelta) {
-					UI::TableNextColumn();
-					UI::SetCursorPosX(UI::GetCursorPos().x + UI::GetContentRegionAvail().x - deltaTextWidth);
-					UI::Text("Delta");
-				}
+				UI::TableNextColumn();
+				UI::SetCursorPosX(UI::GetCursorPos().x + UI::GetContentRegionAvail().x - deltaTextWidth);
+				UI::Text("Delta");
 
 				UI::PopStyleColor();
 			}


### PR DESCRIPTION
Noticed this while working on #62 , but the optional columns logic can be simplified by using `TableSetColumnEnabled`. While the Openplanet documentation says:

> Set to false to hide the column. **User can use the context menu to change this themselves (right-click in headers)**

The actual headers (by using TableHeadersRow) are not rendered by the plugin, so it's not an issue here.

P.S.: This PR is purely to simplify the code / make it easier to maintain, and doesn't change anything for the end user.